### PR TITLE
Fixed Error trying to split integer

### DIFF
--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,5 +1,4 @@
-require File.expand_path('../lib',__FILE__)
-require 'lib/ip_as_int/version'
+require File.expand_path('../lib/ip_as_int/version',__FILE__)
 
 Gem::Specification.new do |gem|
   gem.authors       = ["zelig"]
@@ -13,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "ip_as_int"
   gem.require_paths = ["lib"]
-  gem.version       = IpAsInt::VERSION
+  gem.version       = IpAsInt::VERSION.dup
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path(__FILE__)
+require File.expand_path('../lib',__FILE__)
 require 'lib/ip_as_int/version'
 
 Gem::Specification.new do |gem|

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,5 +1,5 @@
 $:.push File.expand_path("../lib", __FILE__)
-require "devise/version"
+require "ip_as_int/version"
 
 Gem::Specification.new do |gem|
   gem.authors       = ["zelig"]

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "ip_as_int"
   gem.require_paths = ["lib"]
-  gem.version       = IpAsInt::VERSION
+  gem.version       = VERSION
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.version       = IpAsInt::VERSION
 
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'activemodel'
   gem.add_development_dependency 'debugger'

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,4 +1,5 @@
-require File.expand_path('../lib/ip_as_int/version',__FILE__)
+$:.push File.expand_path("../lib", __FILE__)
+require "devise/version"
 
 Gem::Specification.new do |gem|
   gem.authors       = ["zelig"]

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,13 +1,8 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/ip_as_int/version', __FILE__)
-
-DESC = %q{IP address - integer conversion and activerecord support for ip attribute as integer column}
-
 Gem::Specification.new do |gem|
   gem.authors       = ["zelig"]
   gem.email         = ["viktor.tron@gmail.com"]
-  gem.description   = DESC
-  gem.summary       = DESC
+  gem.description   = "IP address - integer conversion and activerecord support for ip attribute as integer column"
+  gem.summary       = gem.description
   gem.homepage      = "https://github.com/zelig/ip_as_int"
 
   gem.files         = `git ls-files`.split($\)

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,3 +1,5 @@
+require File.expand_path('../lib/ip_as_int/version', __FILE__)
+
 Gem::Specification.new do |gem|
   gem.authors       = ["zelig"]
   gem.email         = ["viktor.tron@gmail.com"]

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "ip_as_int"
   gem.require_paths = ["lib"]
-  gem.version       = VERSION
+  gem.version       = IpAsInt::VERSION
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'

--- a/ip_as_int.gemspec
+++ b/ip_as_int.gemspec
@@ -1,4 +1,5 @@
-require File.expand_path('../lib/ip_as_int/version', __FILE__)
+require File.expand_path(__FILE__)
+require 'lib/ip_as_int/version'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["zelig"]

--- a/lib/ip_as_int/ip2int.rb
+++ b/lib/ip_as_int/ip2int.rb
@@ -15,12 +15,16 @@ module IpAsInt::Ip2int
   end
 
   def ip2a(ip_string)
-    ip_a = ip_string.split('.')
-    raise(ArgumentError, "Invalid IP: need 4 parts") unless ip_a.length == 4
-    rexp = /^\d+$/
-    raise(ArgumentError, "Invalid IP: illegal format") unless ip_a.all? { |x| rexp.match(x) }
-    ip_a = ip_a.map(&:to_i)
-    raise(ArgumentError, "Invalid IP: integer out of range") unless ip_a.all? { |x| (0..255).include? x }
+    if ip_string.is_a(Integer)
+      ip_a = ip_string
+    else
+      ip_a = ip_string.split('.')
+      raise(ArgumentError, "Invalid IP: need 4 parts") unless ip_a.length == 4
+      rexp = /^\d+$/
+      raise(ArgumentError, "Invalid IP: illegal format") unless ip_a.all? { |x| rexp.match(x) }
+      ip_a = ip_a.map(&:to_i)
+      raise(ArgumentError, "Invalid IP: integer out of range") unless ip_a.all? { |x| (0..255).include? x 
+    end
     ip_a
   end
 

--- a/lib/ip_as_int/ip2int.rb
+++ b/lib/ip_as_int/ip2int.rb
@@ -15,10 +15,11 @@ module IpAsInt::Ip2int
   end
 
   def ip2a(ip_string)
-    if ip_string.is_a(Integer)
-      return int2ip(ip_string)
+    if ip_string.is_a?(Integer)
+      ip_a = int2ip(ip_string).split('.')
+    else
+      ip_a = ip_string.split('.')
     end
-    ip_a = ip_string.split('.')
     raise(ArgumentError, "Invalid IP: need 4 parts") unless ip_a.length == 4
     rexp = /^\d+$/
     raise(ArgumentError, "Invalid IP: illegal format") unless ip_a.all? { |x| rexp.match(x) }

--- a/lib/ip_as_int/ip2int.rb
+++ b/lib/ip_as_int/ip2int.rb
@@ -23,7 +23,7 @@ module IpAsInt::Ip2int
     rexp = /^\d+$/
     raise(ArgumentError, "Invalid IP: illegal format") unless ip_a.all? { |x| rexp.match(x) }
     ip_a = ip_a.map(&:to_i)
-    raise(ArgumentError, "Invalid IP: integer out of range") unless ip_a.all? { |x| (0..255).include? x
+    raise(ArgumentError, "Invalid IP: integer out of range") unless ip_a.all? { |x| (0..255).include? x }
     ip_a
   end
 

--- a/lib/ip_as_int/ip2int.rb
+++ b/lib/ip_as_int/ip2int.rb
@@ -16,15 +16,14 @@ module IpAsInt::Ip2int
 
   def ip2a(ip_string)
     if ip_string.is_a(Integer)
-      ip_a = ip_string
-    else
-      ip_a = ip_string.split('.')
-      raise(ArgumentError, "Invalid IP: need 4 parts") unless ip_a.length == 4
-      rexp = /^\d+$/
-      raise(ArgumentError, "Invalid IP: illegal format") unless ip_a.all? { |x| rexp.match(x) }
-      ip_a = ip_a.map(&:to_i)
-      raise(ArgumentError, "Invalid IP: integer out of range") unless ip_a.all? { |x| (0..255).include? x 
+      return ip_string
     end
+    ip_a = ip_string.split('.')
+    raise(ArgumentError, "Invalid IP: need 4 parts") unless ip_a.length == 4
+    rexp = /^\d+$/
+    raise(ArgumentError, "Invalid IP: illegal format") unless ip_a.all? { |x| rexp.match(x) }
+    ip_a = ip_a.map(&:to_i)
+    raise(ArgumentError, "Invalid IP: integer out of range") unless ip_a.all? { |x| (0..255).include? x
     ip_a
   end
 

--- a/lib/ip_as_int/ip2int.rb
+++ b/lib/ip_as_int/ip2int.rb
@@ -16,7 +16,7 @@ module IpAsInt::Ip2int
 
   def ip2a(ip_string)
     if ip_string.is_a(Integer)
-      return ip_string
+      return int2ip(ip_string)
     end
     ip_a = ip_string.split('.')
     raise(ArgumentError, "Invalid IP: need 4 parts") unless ip_a.length == 4


### PR DESCRIPTION
I was getting error when using activerecord-import. It runs without callbacks and was causing issues. Now it will not fail when it recieves an integer instead of a string.
